### PR TITLE
Fixing postgresql and redis port

### DIFF
--- a/Web/migrate.sh
+++ b/Web/migrate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export DATABASE_URL="postgres://docker:docker@$DATABASE_POSTGRE_HOST:5432/docker"
-export CELERY_BROKER_URL="redis://$CELERY_BROKER_REDIS_HOST:6379/1"
+export DATABASE_URL="postgres://docker:docker@$DATABASE_POSTGRE_HOST:$DATABASE_POSTGRE_DB_PORT/docker"
+export CELERY_BROKER_URL="redis://$CELERY_BROKER_REDIS_HOST:$CELERY_BROKER_REDIS_BROKER_PORT/1"
 export SES_HOST="$MAIL_EXIM_HOST"
 export SES_USER=""
 export SES_PASS=""

--- a/Web/run.sh
+++ b/Web/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export DATABASE_URL="postgres://docker:docker@$DATABASE_POSTGRE_HOST:5432/docker"
-export CELERY_BROKER_URL="redis://$CELERY_BROKER_REDIS_HOST:6379/1"
+export DATABASE_URL="postgres://docker:docker@$DATABASE_POSTGRE_HOST:$DATABASE_POSTGRE_DB_PORT/docker"
+export CELERY_BROKER_URL="redis://$CELERY_BROKER_REDIS_HOST:$CELERY_BROKER_REDIS_BROKER_PORT/1"
 export SES_HOST="$MAIL_EXIM_HOST"
 export SES_USER=""
 export SES_PASS=""


### PR DESCRIPTION
Hi, We needed to change the ports used by postgresql and redis as they were conflicting with our running servers, but the `run.sh` and `migrate.sh` scripts didn't support that. This pull request fixes this issue.
