### PR TITLE
Update image for redis

### DIFF
--- a/maestro.yml
+++ b/maestro.yml
@@ -26,7 +26,7 @@ services:
           POSTGRESQL_PASS: docker
           POSTGRESQL_DB: docker
   celery_broker:
-    image: dockerfile/redis
+    image: redis
     instances:
       redis:
         ship: vm1


### PR DESCRIPTION
Because image dockerfile/redis moved to image redis without update you can get error like "image not found".