### PR TITLE
Fix invalid service name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ app:
   build: ./Cabot
   links:
     - db
-    - celery_broker
-    - smtp_server
+    - celerybroker
+    - smtp
   volumes:
     - /cabot
   env_file: cabot_env
@@ -16,10 +16,10 @@ db:
     POSTGRESQL_USER: docker
     POSTGRESQL_PASSWORD: docker
 
-celery_broker:
+celerybroker:
   image: redis
 
-smtp_server:
+smtp:
   image: tianon/exim4
 
 nginx:


### PR DESCRIPTION
The docker-compose version 1.3.1 only allow service name in [a-zA-Z0-9].