### PR TITLE
git clone https

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's try
 
 - [Install](https://docs.docker.com/compose/install/) docker-compose.
 
-- Clone the repository (`git clone git@github.com:shoonoise/cabot-docker.git && cd cabot-docker`)
+- Clone the repository (`git clone https://github.com/shoonoise/cabot-docker.git && cd cabot-docker`)
 
 - Run `docker-compose up -d`
 


### PR DESCRIPTION
Otherwise many users without configured git / github will receive this error:
```
Cloning into 'cabot-docker'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```